### PR TITLE
Atomically set O_CLOEXEC on all file descriptors

### DIFF
--- a/vchan-simple/io.c
+++ b/vchan-simple/io.c
@@ -19,6 +19,7 @@
  *
  */
 
+#define _GNU_SOURCE
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -166,14 +167,9 @@ static int wait_for_connection(libvchan_t *ctrl) {
     assert(ctrl->server_fd >= 0);
     assert(ctrl->socket_fd < 0);
 
-    int socket_fd = accept(ctrl->server_fd, NULL, NULL);
+    int socket_fd = accept4(ctrl->server_fd, NULL, NULL, SOCK_NONBLOCK|SOCK_CLOEXEC);
     if (socket_fd < 0) {
         perror("accept");
-        return -1;
-    }
-
-    if (fcntl(socket_fd, F_SETFL, O_NONBLOCK)) {
-        perror("fcntl socket");
         return -1;
     }
 

--- a/vchan-simple/ring.c
+++ b/vchan-simple/ring.c
@@ -37,7 +37,7 @@ int ring_init(struct ring *ring, size_t min_size) {
     ring->start = 0;
     ring->count = 0;
 
-    ring->fd = memfd_create("ring_buffer", 0);
+    ring->fd = memfd_create("ring_buffer", MFD_CLOEXEC);
     if (ring->fd < 0) {
         perror("memfd_create");
         return -1;

--- a/vchan-simple/socket.c
+++ b/vchan-simple/socket.c
@@ -76,7 +76,7 @@ int libvchan__connect(const char *socket_path) {
     ts.tv_sec = 0;
     ts.tv_nsec = CONNECT_DELAY_MS * 1000;
 
-    int socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    int socket_fd = socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0);
     if (socket_fd < 0) {
         perror("socket");
         return -1;

--- a/vchan/init.c
+++ b/vchan/init.c
@@ -55,10 +55,12 @@ static libvchan_t *init(
     if (asprintf(&ctrl->socket_path, "%s/vchan.%d.%d.%d.sock",
                  socket_dir, server_domain, client_domain, port) < 0) {
         perror("asprintf");
+        free(ctrl);
+        return NULL;
     }
 
-    if (pipe2(ctrl->user_event_pipe, O_NONBLOCK) ||
-        pipe2(ctrl->socket_event_pipe, O_NONBLOCK)) {
+    if (pipe2(ctrl->user_event_pipe, O_NONBLOCK|O_CLOEXEC) ||
+        pipe2(ctrl->socket_event_pipe, O_NONBLOCK|O_CLOEXEC)) {
         perror("pipe");
         libvchan_close(ctrl);
         return NULL;

--- a/vchan/node-select.c
+++ b/vchan/node-select.c
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
 		fd_set rfds;
 		FD_ZERO(&rfds);
 		FD_SET(0, &rfds);
-        libvchan_fd = libvchan_fd_for_select(ctrl);
+                libvchan_fd = libvchan_fd_for_select(ctrl);
 		FD_SET(libvchan_fd, &rfds);
 //		libvchan_prepare_to_select(ctrl);
 		ret = select(libvchan_fd + 1, &rfds, NULL, NULL, NULL);

--- a/vchan/ring.c
+++ b/vchan/ring.c
@@ -37,7 +37,7 @@ int ring_init(struct ring *ring, size_t min_size) {
     ring->start = 0;
     ring->count = 0;
 
-    ring->fd = memfd_create("ring_buffer", 0);
+    ring->fd = memfd_create("ring_buffer", MFD_CLOEXEC);
     if (ring->fd < 0) {
         perror("memfd_create");
         return -1;

--- a/vchan/socket.c
+++ b/vchan/socket.c
@@ -46,15 +46,9 @@ int libvchan__listen(const char *socket_path) {
         return -1;
     }
 
-    server_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    server_fd = socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC|SOCK_NONBLOCK, 0);
     if (server_fd < 0) {
         perror("socket");
-        return -1;
-    }
-
-    if (fcntl(server_fd, F_SETFL, O_NONBLOCK)) {
-        perror("fcntl server_fd");
-        close(server_fd);
         return -1;
     }
 
@@ -114,7 +108,7 @@ int libvchan__connect(const char *socket_path) {
     ts.tv_sec = 0;
     ts.tv_nsec = CONNECT_DELAY_MS * 1000;
 
-    int socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    int socket_fd = socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0);
     if (socket_fd < 0) {
         perror("socket");
         return -1;


### PR DESCRIPTION
All libraries should do this, and it would have prevented a hard-to-debug hang in the qrexec unit tests.